### PR TITLE
fix: prevent stale save abort from wiping chat history

### DIFF
--- a/components/ai-chat/hooks/use-chat-sync.ts
+++ b/components/ai-chat/hooks/use-chat-sync.ts
@@ -181,12 +181,9 @@ export function useDebouncedCloudSave({
           setCloudError(null)
 
           try {
-            // Clear existing messages and save all current ones as a single ordered operation.
+            // Once we begin replacing messages, always complete clear+save together.
+            // Returning early after clear can leave the session empty during rapid save invalidations.
             await chatService.clearMessages(session.id)
-
-            if (requestId !== latestCloudSaveRequestRef.current) {
-              return
-            }
 
             const dbMessages = msgs.map((msg) => chatService.convertToDbMessage(msg))
             await chatService.saveMessages(session.id, dbMessages)


### PR DESCRIPTION
## Summary\n- keep stale-check before destructive work begins\n- once message replacement starts, always complete clear+save to avoid empty sessions\n- preserve existing queue semantics and latest-save UI updates\n\nFixes #3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cloud persistence logic: removing the post-`clearMessages` stale-check reduces protection against outdated writes, but prevents an empty-session failure mode during rapid invalidations.
> 
> **Overview**
> Prevents chat history from being wiped when a debounced cloud save is invalidated mid-operation.
> 
> In `useDebouncedCloudSave` (`use-chat-sync.ts`), the PR keeps the stale-request check *before* destructive work, but removes the early return after `chatService.clearMessages`, ensuring the clear+save sequence always completes once started so a session can’t be left empty during rapid save invalidations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9078e3523dcd5d52b44a4cb508030284501089c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->