### PR TITLE
fix: clear workflow canvas timers on unmount

### DIFF
--- a/components/workflow/workflow-canvas.tsx
+++ b/components/workflow/workflow-canvas.tsx
@@ -87,11 +87,12 @@ export const WorkflowCanvas = forwardRef<WorkflowCanvasHandle, WorkflowCanvasPro
   }, [])
 
   useEffect(() => {
+    const handles = timeoutHandlesRef.current
     return () => {
-      for (const handle of timeoutHandlesRef.current) {
+      for (const handle of handles) {
         clearTimeout(handle)
       }
-      timeoutHandlesRef.current.clear()
+      handles.clear()
     }
   }, [])
 


### PR DESCRIPTION
## Summary
- centralize workflow-canvas setTimeout scheduling through a tracked timeout registry
- clear all pending timeout handles in effect cleanup on unmount
- route existing add/beautify/run timer calls through the tracked scheduler

Fixes #6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to UI timer scheduling/cleanup that reduces risk of state updates after unmount; behavior should be functionally equivalent aside from preventing late callbacks.
> 
> **Overview**
> Prevents `WorkflowCanvas` from running delayed callbacks after unmount by centralizing `setTimeout` usage behind a `scheduleTimeout` helper that registers handles and removes them when fired.
> 
> Adds an effect cleanup that clears all pending timeouts on unmount, and routes existing delayed actions (e.g., `fitView` after `addWorkflow`/`beautifyWorkflow`, and the simulated completion in `runWorkflow`) through the tracked scheduler; also updates `useImperativeHandle`/`runWorkflow` dependencies accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b6f5746caae94c91bd93d223930cbe65f3fefc2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->