### PR TITLE
fix(ci): remove duplicate pnpm version declaration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- remove explicit version from pnpm/action-setup@v4
- keep package.json packageManager as the single pnpm version source
- resolves CI failure: Multiple versions of pnpm specified

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that simplifies pnpm setup; minimal risk beyond potentially changing which pnpm version CI picks up.
> 
> **Overview**
> Removes the explicit `version: 10` configuration from `pnpm/action-setup` in the CI workflow, relying on the single pnpm version source instead.
> 
> This avoids the GitHub Actions failure caused by specifying multiple pnpm versions during setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6e05cab37e751765c7162eb81a5a3d42b4df5e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->